### PR TITLE
build, feature: 멀티 데이터 소스를 적용한다.

### DIFF
--- a/query-server/src/main/java/project/goorm/queryserver/QueryServerApplication.java
+++ b/query-server/src/main/java/project/goorm/queryserver/QueryServerApplication.java
@@ -2,8 +2,9 @@ package project.goorm.queryserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 public class QueryServerApplication {
 
     public static void main(String[] args) {

--- a/query-server/src/main/java/project/goorm/queryserver/common/configuration/rdb/DataSourceConfiguration.java
+++ b/query-server/src/main/java/project/goorm/queryserver/common/configuration/rdb/DataSourceConfiguration.java
@@ -1,0 +1,55 @@
+package project.goorm.queryserver.common.configuration.rdb;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+
+@Configuration
+@EnableTransactionManagement
+@EnableJpaRepositories(basePackages = {"project.goorm.queryserver"})
+public class DataSourceConfiguration {
+
+    @Bean
+    @ConfigurationProperties(prefix = "spring.datasource.master")
+    public DataSource masterDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @Bean
+    @ConfigurationProperties(prefix = "spring.datasource.replication")
+    public DataSource replicationDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @Bean
+    public DataSource routingDataSource(
+            @Qualifier("masterDataSource") DataSource masterDataSource,
+            @Qualifier("replicationDataSource") DataSource replicationDataSource
+    ) {
+        DynamicRoutingDataSource routingDataSource = new DynamicRoutingDataSource();
+
+        HashMap<Object, Object> dataSourceMap = new HashMap<>();
+        dataSourceMap.put("master", masterDataSource);
+        dataSourceMap.put("replication", replicationDataSource);
+
+        routingDataSource.setTargetDataSources(dataSourceMap);
+        routingDataSource.setDefaultTargetDataSource(masterDataSource);
+        return routingDataSource;
+    }
+
+    @Bean
+    @Primary
+    public DataSource dataSource(@Qualifier("routingDataSource") DataSource routingDataSource) {
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+}

--- a/query-server/src/main/java/project/goorm/queryserver/common/configuration/rdb/DynamicRoutingDataSource.java
+++ b/query-server/src/main/java/project/goorm/queryserver/common/configuration/rdb/DynamicRoutingDataSource.java
@@ -1,0 +1,13 @@
+package project.goorm.queryserver.common.configuration.rdb;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+
+import static org.springframework.transaction.support.TransactionSynchronizationManager.isCurrentTransactionReadOnly;
+
+public class DynamicRoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        return isCurrentTransactionReadOnly() ? "replication" : "master";
+    }
+}


### PR DESCRIPTION
## 📌 상세 내용
&nbsp;&nbsp; - READ/REPLICATION을 분리하기 위한 멀티 데이터 소스 적용

<br/><br/><br/>

## 🐳 구현 사항

데이터 소스를 두 개로 분리해서 읽기용/쓰기 용으로 분리했습니다. 이를 통해 별도의 각자의 역할에 맞는 데이터베이스로 요청을 해서 조금이나마 부하를 분산하고자 했습니다.

```java
public class DynamicRoutingDataSource extends AbstractRoutingDataSource {

    @Override
    protected Object determineCurrentLookupKey() {
        return isCurrentTransactionReadOnly() ? "replication" : "master";
    }
}
```