### PR TITLE
bug: redis 설정을 변경한다.

### DIFF
--- a/query-server/build.gradle
+++ b/query-server/build.gradle
@@ -57,8 +57,8 @@ dependencies {
     testImplementation('org.springframework.boot:spring-boot-starter-test')
     testImplementation('org.springframework.restdocs:spring-restdocs-mockmvc')
     testImplementation('org.springframework.restdocs:spring-restdocs-restassured')
-    testImplementation "org.testcontainers:testcontainers:1.17.6"
     testImplementation "org.testcontainers:junit-jupiter:1.17.6"
+
 
     // Lombok
     compileOnly('org.projectlombok:lombok:1.18.22')

--- a/query-server/src/main/java/project/goorm/queryserver/common/configuration/redis/RedisConfiguration.java
+++ b/query-server/src/main/java/project/goorm/queryserver/common/configuration/redis/RedisConfiguration.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
@@ -29,16 +30,13 @@ public class RedisConfiguration {
     @Value("${spring.redis.port}")
     private int port;
 
-    @Primary
     @Bean(name = "redisCacheConnectionFactory")
     public RedisConnectionFactory redisCacheConnectionFactory() {
-        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
-        redisStandaloneConfiguration.setHostName(host);
-        redisStandaloneConfiguration.setPort(port);
+        RedisClusterConfiguration redisStandaloneConfiguration = new RedisClusterConfiguration();
+        redisStandaloneConfiguration.clusterNode(host, port);
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 
-    @Primary
     @Bean
     public RedisCacheManager cacheManager(@Qualifier("redisCacheConnectionFactory") RedisConnectionFactory connectionFactory) {
         RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()


### PR DESCRIPTION
## 📌 상세 내용
<br/>
&nbsp; - 레디스 설정이 클러스터링용이 아니었다 해당 부분을 변경한다.
<br/>
&nbsp; - 클러스터링용으로 설정을 바꾸고 테스트 환경은 하나의 레디스 서버를 쓰도록 환경을 분리한다.
